### PR TITLE
Routing Change

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -2,7 +2,7 @@ collections:
   /:
     permalink: /music/{slug}/
     template: index
-    filter: tag:music
+    filter: tag:[newsletter,music]
   /newsletter/:
     permalink: /newsletter/{slug}/
     template: index


### PR DESCRIPTION
This change has to be installed directly through the Ghost admin, so this PR will not be merged until a change of the theme.

fixes #10